### PR TITLE
Proposed

### DIFF
--- a/core/admin/void_transaction.php
+++ b/core/admin/void_transaction.php
@@ -290,7 +290,9 @@ function handle_void_transaction()
 			display_notification_centered(_("Selected transaction has been voided."));
 			unset($_POST['trans_no']);
 			unset($_POST['memo_']);
-			unset($_POST['date_']);
+            // no reason to unset the user's chosen date
+            // which can be used for subsequent voids
+			// unset($_POST['date_']);
 		}
 		else {
 			display_error($msg);

--- a/core/gl/bank_account_reconcile.php
+++ b/core/gl/bank_account_reconcile.php
@@ -90,6 +90,12 @@ function fmt_person($trans)
 	return get_counterparty_name($trans["type"], $trans["trans_no"]);
 }
 
+function fmt_memo($row)
+{
+	$value = $row["memo_"];
+	return $value;
+}
+
 function update_data()
 {
 	global $Ajax;
@@ -124,6 +130,26 @@ function change_tpl_flag($reconcile_id)
 	return true;
 }
 
+function set_tpl_flag($reconcile_id)
+{
+	global	$Ajax;
+
+	if (check_value("rec_".$reconcile_id))
+		return;
+
+	if (get_post('bank_date')=='')	// new reconciliation
+		$Ajax->activate('bank_date');
+
+	$_POST['bank_date'] = date2sql(get_post('reconcile_date'));
+	$reconcile_value =  ("'".$_POST['bank_date'] ."'");
+	
+	update_reconciled_values($reconcile_id, $reconcile_value, $_POST['reconcile_date'],
+		input_num('end_balance'), $_POST['bank_account']);
+		
+	$Ajax->activate('reconciled');
+	$Ajax->activate('difference');
+}
+
 if (!isset($_POST['reconcile_date'])) { // init page
 	$_POST['reconcile_date'] = new_doc_date();
 //	$_POST['bank_date'] = date2sql(Today());
@@ -148,11 +174,22 @@ $id = find_submit('_rec_');
 if ($id != -1) 
 	change_tpl_flag($id);
 
+/*
 if (isset($_POST['Reconcile'])) {
 	set_focus('bank_date');
 	foreach($_POST['last'] as $id => $value)
 		if ($value != check_value('rec_'.$id))
 			if(!change_tpl_flag($id)) break;
+
+    $Ajax->activate('_page_body');
+}
+*/
+
+if (isset($_POST['ReconcileAll'])) {
+	set_focus('bank_date');
+	foreach($_POST['last'] as $id => $value)
+		set_tpl_flag($id);
+
     $Ajax->activate('_page_body');
 }
 
@@ -234,6 +271,7 @@ display_heading($act['bank_account_name']." - ".$act['bank_curr_code']);
 		_("Debit") => array('align'=>'right', 'fun'=>'fmt_debit'), 
 		_("Credit") => array('align'=>'right','insert'=>true, 'fun'=>'fmt_credit'), 
 	    _("Person/Item") => array('fun'=>'fmt_person'), 
+		_("Memo") => array('fun'=>'fmt_memo'),
 		array('insert'=>true, 'fun'=>'gl_view'),
 		"X"=>array('insert'=>true, 'fun'=>'rec_checkbox')
 	   );
@@ -243,7 +281,8 @@ display_heading($act['bank_account_name']." - ".$act['bank_curr_code']);
 	display_db_pager($table);
 
 br(1);
-submit_center('Reconcile', _("Reconcile"), true, '', null);
+//submit_center('Reconcile', _("Reconcile"), true, '', null);
+submit_center('ReconcileAll', _("Reconcile All"), true, '');
 
 end_form();
 

--- a/core/gl/gl_bank.php
+++ b/core/gl/gl_bank.php
@@ -300,6 +300,16 @@ if (isset($_POST['Process']) && !check_trans())
 
 	$trans_type = $trans[0];
    	$trans_no = $trans[1];
+
+        // retain the reconciled status if desired by user
+        if (isset($_POST['reconciled'])
+            && $_POST['reconciled'] == 1) {
+            $sql = "UPDATE ".TB_PREF."bank_trans SET reconciled=".db_escape($_POST['reconciled_date'])
+                ." WHERE type=" . $trans_type . " AND trans_no=".db_escape($trans_no);
+
+            db_query($sql, "Can't change reconciliation status");
+        }
+
 	new_doc_date($_POST['date_']);
 
 	$_SESSION['pay_items']->clear_items();

--- a/core/gl/gl_journal.php
+++ b/core/gl/gl_journal.php
@@ -328,7 +328,7 @@ if (isset($_POST['Process']))
 	$trans_no = write_journal_entries($cart);
 
         // retain the reconciled status if desired by user
-        if (isset($_POST['reconciled])
+        if (isset($_POST['reconciled'])
             && $_POST['reconciled'] == 1) {
             $sql = "UPDATE ".TB_PREF."bank_trans SET reconciled=".db_escape($_POST['reconciled_date'])
                 ." WHERE type=" . ST_JOURNAL . " AND trans_no=".db_escape($trans_no);

--- a/core/gl/gl_journal.php
+++ b/core/gl/gl_journal.php
@@ -129,7 +129,6 @@ function create_cart($type=0, $trans_no=0)
 		}
 		$cart->memo_ = get_comments_string($type, $trans_no);
 		$cart->reference = $header['reference'];
-
 		// update net_amounts from tax register
 
 		// retrieve tax details
@@ -327,6 +326,15 @@ if (isset($_POST['Process']))
 	} else
 		$cart->tax_info = false;
 	$trans_no = write_journal_entries($cart);
+
+        // retain the reconciled status if desired by user
+        if (isset($_POST['reconciled])
+            && $_POST['reconciled'] == 1) {
+            $sql = "UPDATE ".TB_PREF."bank_trans SET reconciled=".db_escape($_POST['reconciled_date'])
+                ." WHERE type=" . ST_JOURNAL . " AND trans_no=".db_escape($trans_no);
+
+            db_query($sql, "Can't change reconciliation status");
+        }
 
 	$cart->clear_items();
 	new_doc_date($_POST['date_']);

--- a/core/gl/includes/db/gl_db_bank_accounts.inc
+++ b/core/gl/includes/db/gl_db_bank_accounts.inc
@@ -277,13 +277,15 @@ function get_ending_reconciled($bank_account, $bank_date)
 
 function get_sql_for_bank_account_reconcile($bank_account, $date)
 {
-	$sql = "SELECT	type, trans_no, ref, trans_date,
-				amount,	person_id, person_type_id, reconciled, id
-		FROM ".TB_PREF."bank_trans
+	$sql = "SELECT	bt.type, trans_no, ref, trans_date,
+				amount,	person_id, person_type_id, reconciled, bt.id, c.memo_
+		FROM ".TB_PREF."bank_trans bt
+		LEFT JOIN ".TB_PREF."comments c ON c.type = bt.type AND c.id = bt.trans_no
 		WHERE bank_act = ".db_escape($bank_account) . "
 			AND (reconciled IS NULL OR reconciled='". date2sql($date) ."')
 			AND amount != 0
-		ORDER BY trans_date, id";
+		ORDER BY trans_date, bt.id";
+
 	return $sql;
 }
 

--- a/core/gl/includes/db/gl_db_bank_trans.inc
+++ b/core/gl/includes/db/gl_db_bank_trans.inc
@@ -49,6 +49,18 @@ function add_bank_trans($type, $trans_no, $bank_act, $ref, $date_,
 
 //----------------------------------------------------------------------------------------
 
+function last_bank_trans($field)
+{
+	$sql = "SELECT " . $field . 
+		" FROM ".TB_PREF."bank_trans
+                ORDER BY id DESC LIMIT 1";
+	$last_query = db_query($sql, "query for last bank transaction");
+	$row = db_fetch_row($last_query);
+        return $row[0];
+}
+
+//----------------------------------------------------------------------------------------
+
 function exists_bank_trans($type, $type_no)
 {
 	$sql = "SELECT trans_no

--- a/core/gl/includes/db/gl_db_trans.inc
+++ b/core/gl/includes/db/gl_db_trans.inc
@@ -105,7 +105,7 @@ function add_gl_balance($type, $trans_id, $date_, $amount, $person_type_id=null,
 
 function get_gl_transactions($from_date, $to_date, $trans_no=0,
 	$account=null, $dimension=0, $dimension2=0, $filter_type=null,
-	$amount_min=null, $amount_max=null, $person_id=null)
+        $amount_min=null, $amount_max=null, $person_id=null, $memo='')
 {
 	global $SysPrefs;
 
@@ -115,6 +115,7 @@ function get_gl_transactions($from_date, $to_date, $trans_no=0,
 	$sql = "SELECT gl.*, j.event_date, j.doc_date, a.gl_seq, u.user_id, st.supp_reference, gl.person_id subcode,
 			IFNULL(IFNULL(sup.supp_name, debt.name), bt.person_id) as person_name, 
 			IFNULL(gl.person_id, IFNULL(sup.supplier_id, debt.debtor_no)) as person_id,
+                        IF(gl.person_id, gl.person_type_id, IF(sup.supplier_id,".  PT_SUPPLIER . "," .  "IF(debt.debtor_no," . PT_CUSTOMER . ", -1))) as person_type_id,
 			IFNULL(st.tran_date, IFNULL(dt.tran_date, IFNULL(bt.trans_date, IFNULL(grn.delivery_date, gl.tran_date)))) as doc_date,
 			coa.account_name, ref.reference
 			 FROM "
@@ -153,10 +154,10 @@ function get_gl_transactions($from_date, $to_date, $trans_no=0,
 	if ($account != null)
 		$sql .= " AND gl.account = ".db_escape($account);
 
-	if ($dimension > 0)
+	if ($dimension != 0)
 		$sql .= " AND gl.dimension_id = ".($dimension<0 ? 0 : db_escape($dimension));
 
-	if ($dimension2 > 0)
+	if ($dimension2 != 0)
 		$sql .= " AND gl.dimension2_id = ".($dimension2<0 ? 0 : db_escape($dimension2));
 
 	if ($filter_type != null AND is_numeric($filter_type))
@@ -167,6 +168,10 @@ function get_gl_transactions($from_date, $to_date, $trans_no=0,
 	
 	if ($amount_max != null)
 		$sql .= " AND ABS(gl.amount) <= ABS(".db_escape($amount_max).")";
+
+        if ($memo) {
+                $sql .= " AND gl.memo_ LIKE ". db_escape("%$memo%");
+        }
 
 	$sql .= " ORDER BY tran_date, counter";
 

--- a/core/gl/includes/ui/gl_bank_ui.inc
+++ b/core/gl/includes/ui/gl_bank_ui.inc
@@ -122,7 +122,7 @@ function display_bank_header(&$order)
 
         // Query the user to retain the reconciled status
         if (!$new) {
-            $result = get_bank_trans(ST_JOURNAL, $order->order_id);
+            $result = get_bank_trans($order->trans_type, $order->order_id);
             $row = db_fetch($result);
             if ($row
                 && $row['reconciled'] != "") {

--- a/core/gl/includes/ui/gl_bank_ui.inc
+++ b/core/gl/includes/ui/gl_bank_ui.inc
@@ -13,6 +13,7 @@ function display_bank_header(&$order)
 {
 	global $Ajax;
 	$payment = $order->trans_type == ST_BANKPAYMENT;
+        $new = $order->order_id==0;
 
 	$customer_error = false;
 	div_start('pmt_header');
@@ -118,6 +119,17 @@ function display_bank_header(&$order)
 	$bank_currency = get_bank_account_currency($_POST['bank_account']);
 
 	exchange_rate_display(get_company_currency(), $bank_currency, $_POST['date_']);
+
+        // Query the user to retain the reconciled status
+        if (!$new) {
+            $result = get_bank_trans(ST_JOURNAL, $order->order_id);
+            $row = db_fetch($result);
+            if ($row
+                && $row['reconciled'] != "") {
+                check_row(_('Reconciled:'), 'reconciled', 1, true);
+                hidden('reconciled_date', $row['reconciled']);
+            }
+        }
 
 	end_outer_table(1); // outer table
 

--- a/core/gl/includes/ui/gl_bank_ui.inc
+++ b/core/gl/includes/ui/gl_bank_ui.inc
@@ -238,21 +238,25 @@ function gl_edit_item_controls(&$order, $dim, $Index=null)
 		{
 			$acc = get_branch_accounts($_POST['PersonDetailID']);
 			$_POST['code_id'] = $acc['receivables_account'];
+                        $dim1 = $dim2 = null;
 		}
 		elseif ($_POST['PayType'] == PT_SUPPLIER)
 		{
 			$acc = get_supplier_accounts($_POST['person_id']);
 			$_POST['code_id'] = $acc['payable_account'];
+                        $dim1 = $acc['dimension_id'];
+                        $dim2 = $acc['dimension2_id'];
 		}
 		else {
 			$_POST['code_id'] =
 				get_company_pref($payment ? 'default_cogs_act':'default_inv_sales_act');
+                        $dim1 = $dim2 = null;
 		}
 		echo gl_all_accounts_list('code_id', null, true, true);
 		if ($dim >= 1)
-			dimensions_list_cells(null, 'dimension_id', null, true, " ", false, 1);
+			dimensions_list_cells(null, 'dimension_id', $dim1, true, " ", false, 1);
 		if ($dim > 1)
-			dimensions_list_cells(null, 'dimension2_id', null, true, " ", false, 2);
+			dimensions_list_cells(null, 'dimension2_id', $dim2, true, " ", false, 2);
 	}
 	if ($dim < 1)
 		hidden('dimension_id', 0);

--- a/core/gl/includes/ui/gl_journal_ui.inc
+++ b/core/gl/includes/ui/gl_journal_ui.inc
@@ -79,6 +79,17 @@ function display_order_header(&$Order)
 	}
 
 	check_row(_('Include in tax register:'), 'taxable_trans', null, true);
+
+        // Query the user to retain the reconciled status
+        if (!$new) {
+            $result = get_bank_trans(ST_JOURNAL, $Order->order_id);
+            $row = db_fetch($result);
+            if ($row
+                && $row['reconciled'] != "") {
+                check_row(_('Reconciled:'), 'reconciled', 1, true);
+                hidden('reconciled_date', $row['reconciled']);
+            }
+        }
 	end_outer_table(1);
 }
 

--- a/core/gl/inquiry/gl_account_inquiry.php
+++ b/core/gl/inquiry/gl_account_inquiry.php
@@ -13,6 +13,7 @@ $page_security = 'SA_GLTRANSVIEW';
 $path_to_root = "../..";
 include_once($path_to_root . "/includes/session.inc");
 
+include($path_to_root . "/includes/db_pager.inc");
 
 include_once($path_to_root . "/admin/db/fiscalyears_db.inc");
 include_once($path_to_root . "/includes/date_functions.inc");
@@ -75,11 +76,15 @@ function gl_inquiry_controls()
 
 	start_table(TABLESTYLE_NOBORDER);
 	start_row();
-	if ($dim >= 1)
+        if (!isset($_POST['Dimension'])
+            || $_POST['Dimension'] != -1) {
+            if ($dim >= 1)
 		dimensions_list_cells(_("Dimension")." 1:", 'Dimension', null, true, " ", false, 1);
-	if ($dim > 1)
+            if ($dim > 1)
 		dimensions_list_cells(_("Dimension")." 2:", 'Dimension2', null, true, " ", false, 2);
+        }
 
+        ref_cells(_("Memo:"), 'Memo', '',null, _('Enter memo fragment or leave empty'));
 	small_amount_cells(_("Amount min:"), 'amount_min', null, " ");
 	small_amount_cells(_("Amount max:"), 'amount_max', null, " ");
 	submit_cells('Show',_("Show"),'','', 'default');
@@ -109,7 +114,7 @@ function show_results()
     	$_POST['Dimension2'] = 0;
 	$result = get_gl_transactions($_POST['TransFromDate'], $_POST['TransToDate'], -1,
     	$_POST["account"], $_POST['Dimension'], $_POST['Dimension2'], null,
-    	input_num('amount_min'), input_num('amount_max'));
+    	input_num('amount_min'), input_num('amount_max'), null, $_POST['Memo']);
 
 	$colspan = ($dim == 2 ? "6" : ($dim == 1 ? "5" : "4"));
 
@@ -142,7 +147,7 @@ function show_results()
 	else
 	    $remaining_cols = array(_("Person/Item"), _("Debit"), _("Credit"), _("Memo"));
 	    
-	$th = array_merge($first_cols, $account_col, $dim_cols, $remaining_cols);
+	$th = array_merge($first_cols, $account_col, $dim_cols, $remaining_cols, array(""));
 			
 	table_header($th);
 	if ($_POST["account"] != null && is_account_balancesheet($_POST["account"]))
@@ -197,6 +202,10 @@ function show_results()
 		if ($myrow['memo_'] == "")
 			$myrow['memo_'] = get_comments_string($myrow['type'], $myrow['type_no']);
     	label_cell($myrow['memo_']);
+        if ($myrow["type"] == ST_JOURNAL)
+            echo "<td>" . trans_editor_link( $myrow["type"], $myrow["type_no"]) . "</td>";
+        else
+            label_cell("");
     	end_row();
 
     	$j++;

--- a/core/gl/inquiry/gl_account_inquiry.php
+++ b/core/gl/inquiry/gl_account_inquiry.php
@@ -95,6 +95,19 @@ function gl_inquiry_controls()
     end_form();
 }
 
+function edit_link($row)
+{
+
+        $ok = true;
+        if ($row['type'] == ST_SALESINVOICE)
+        {
+                $myrow = get_customer_trans($row["type_no"], $row["type"]);
+                if ($myrow['alloc'] != 0 || get_voided_entry(ST_SALESINVOICE, $row["type_no"]) !== false)
+                        $ok = false;
+        }
+        return $ok ? trans_editor_link( $row["type"], $row["type_no"]) : '';
+}
+
 //----------------------------------------------------------------------------------------------------
 
 function show_results()
@@ -202,10 +215,7 @@ function show_results()
 		if ($myrow['memo_'] == "")
 			$myrow['memo_'] = get_comments_string($myrow['type'], $myrow['type_no']);
     	label_cell($myrow['memo_']);
-        if ($myrow["type"] == ST_JOURNAL)
-            echo "<td>" . trans_editor_link( $myrow["type"], $myrow["type_no"]) . "</td>";
-        else
-            label_cell("");
+        echo "<td>" . edit_link($myrow) . "</td>";
     	end_row();
 
     	$j++;

--- a/core/purchasing/includes/db/suppliers_db.inc
+++ b/core/purchasing/includes/db/suppliers_db.inc
@@ -149,7 +149,7 @@ function get_supplier_name($supplier_id)
 
 function get_supplier_accounts($supplier_id)
 {
-	$sql = "SELECT payable_account,purchase_account,payment_discount_account FROM ".TB_PREF."suppliers WHERE supplier_id=".db_escape($supplier_id);
+	$sql = "SELECT payable_account,purchase_account,payment_discount_account, dimension_id, dimension2_id FROM ".TB_PREF."suppliers WHERE supplier_id=".db_escape($supplier_id);
 
 	$result = db_query($sql, "could not get supplier");
 

--- a/core/reporting/rep105.php
+++ b/core/reporting/rep105.php
@@ -122,20 +122,22 @@ function print_order_status_list()
 
 	$aligns2 = $aligns;
 
-	$rep = new FrontReport(_('Order Status Listing'), "OrderStatusListing", user_pagesize(), 9, $orientation);
-    if ($orientation == 'L')
-    	recalculate_cols($cols);
-	$cols2 = $cols;
-	$rep->Font();
-	$rep->Info($params, $cols, $headers, $aligns, $cols2, $headers2, $aligns2);
-
-	$rep->NewPage();
 	$orderno = 0;
 
 	$result = GetSalesOrders($from, $to, $category, $location, $backorder);
 
 	while ($myrow=db_fetch($result))
 	{
+                if (!isset($rep)) {
+                    $rep = new FrontReport(_('Order Status Listing'), "OrderStatusListing", user_pagesize(), 9, $orientation);
+                if ($orientation == 'L')
+                    recalculate_cols($cols);
+                    $cols2 = $cols;
+                    $rep->Font();
+                    $rep->Info($params, $cols, $headers, $aligns, $cols2, $headers2, $aligns2);
+
+                    $rep->NewPage();
+                }
 		$rep->NewLine(0, 2, false, $orderno);
 		if ($orderno != $myrow['order_no'])
 		{
@@ -168,7 +170,11 @@ function print_order_status_list()
 		}
 		$rep->NewLine();
 	}
-	$rep->Line($rep->row);
-	$rep->End();
+        if (!isset($rep))
+            display_notification("No sales orders found");
+        else {
+            $rep->Line($rep->row);
+            $rep->End();
+        }
 }
 

--- a/core/reporting/rep106.php
+++ b/core/reporting/rep106.php
@@ -100,14 +100,6 @@ function print_salesman_list()
 
 	$aligns2 = $aligns;
 
-	$rep = new FrontReport(_('Salesman Listing'), "SalesmanListing", user_pagesize(), 9, $orientation);
-    if ($orientation == 'L')
-    	recalculate_cols($cols);
-	$cols2 = $cols;
-	$rep->Font();
-	$rep->Info($params, $cols, $headers, $aligns, $cols2, $headers2, $aligns2);
-
-	$rep->NewPage();
 	$salesman = 0;
 	$subtotal = $total = $subprov = $provtotal = 0;
 
@@ -115,6 +107,16 @@ function print_salesman_list()
 
 	while ($myrow=db_fetch($result))
 	{
+                if (!isset($rep)) {
+                    $rep = new FrontReport(_('Salesman Listing'), "SalesmanListing", user_pagesize(), 9, $orientation);
+                if ($orientation == 'L')
+                    recalculate_cols($cols);
+                    $cols2 = $cols;
+                    $rep->Font();
+                    $rep->Info($params, $cols, $headers, $aligns, $cols2, $headers2, $aligns2);
+
+                    $rep->NewPage();
+                }
 		$rep->NewLine(0, 2, false, $salesman);
 		if ($salesman != $myrow['salesman_code'])
 		{
@@ -165,25 +167,30 @@ function print_salesman_list()
 		$subtotal += $amt;
 		$subprov += $prov;
 	}
-	if ($salesman != 0)
-	{
-		$rep->Line($rep->row - 4);
-		$rep->NewLine(2);
-		$rep->TextCol(0, 3, _('Total'));
-		$rep->AmountCol(5, 6, $subtotal, $dec);
-		$rep->AmountCol(6, 7, $subprov, $dec);
-		$rep->Line($rep->row  - 4);
-		$rep->NewLine(2);
-		$total += $subtotal;
-		$provtotal += $subprov;
-	}
-	$rep->fontSize += 2;
-	$rep->TextCol(0, 3, _('Grand Total'));
-	$rep->fontSize -= 2;
-	$rep->AmountCol(5, 6, $total, $dec);
-	$rep->AmountCol(6, 7, $provtotal, $dec);
-	$rep->Line($rep->row  - 4);
-	$rep->NewLine();
-	$rep->End();
+
+        if (!isset($rep))
+            display_notification("No salesman transactions found");
+        else {
+            if ($salesman != 0)
+            {
+                    $rep->Line($rep->row - 4);
+                    $rep->NewLine(2);
+                    $rep->TextCol(0, 3, _('Total'));
+                    $rep->AmountCol(5, 6, $subtotal, $dec);
+                    $rep->AmountCol(6, 7, $subprov, $dec);
+                    $rep->Line($rep->row  - 4);
+                    $rep->NewLine(2);
+                    $total += $subtotal;
+                    $provtotal += $subprov;
+            }
+            $rep->fontSize += 2;
+            $rep->TextCol(0, 3, _('Grand Total'));
+            $rep->fontSize -= 2;
+            $rep->AmountCol(5, 6, $total, $dec);
+            $rep->AmountCol(6, 7, $provtotal, $dec);
+            $rep->Line($rep->row  - 4);
+            $rep->NewLine();
+            $rep->End();
+        }
 }
 

--- a/core/reporting/rep108.php
+++ b/core/reporting/rep108.php
@@ -77,8 +77,6 @@ function print_statements()
 	$PastDueDays1 = get_company_pref('past_due_days');
 	$PastDueDays2 = 2 * $PastDueDays1;
 
-	if ($email == 0)
-		$rep = new FrontReport(_('STATEMENT'), "StatementBulk", user_pagesize(), 9, $orientation);
     if ($orientation == 'L')
     	recalculate_cols($cols);
 
@@ -103,6 +101,8 @@ function print_statements()
 		$params['bankaccount'] = $baccount['id'];
 		if (db_num_rows($TransResult) == 0)
 			continue;
+                if ($email == 0 && !isset($rep))
+                        $rep = new FrontReport(_('STATEMENT'), "StatementBulk", user_pagesize(), 9, $orientation);
 		if ($email == 1)
 		{
 			$rep = new FrontReport("", "", user_pagesize(), 9, $orientation);
@@ -170,7 +170,10 @@ function print_statements()
 			$rep->End($email, _("Statement") . " " . _("as of") . " " . sql2date($date));
 
 	}
-	if ($email == 0)
+
+        if (!isset($rep))
+            display_notification("No customers with outstanding balances found");
+	else if ($email == 0)
 		$rep->End();
 }
 

--- a/core/sales/includes/db/sales_invoice_db.inc
+++ b/core/sales/includes/db/sales_invoice_db.inc
@@ -203,7 +203,7 @@ function write_sales_invoice(&$invoice)
 				$Refs->get_next(ST_CUSTPAYMENT, null, array('customer' => $invoice->customer_id,
 					'branch' => $invoice->Branch, 'date' => $date_)),
 				$amount-$discount, $discount,
-				_('Cash invoice').' '.$invoice_no);
+				$invoice->pos['pos_name'].' #'.$invoice_no);
 			add_cust_allocation($amount, ST_CUSTPAYMENT, $pmtno, ST_SALESINVOICE, $invoice_no, $invoice->customer_id, $date_);
 
 			update_debtor_trans_allocation(ST_SALESINVOICE, $invoice_no, $invoice->customer_id);

--- a/core/sales/includes/db/sales_order_db.inc
+++ b/core/sales/includes/db/sales_order_db.inc
@@ -626,3 +626,17 @@ function is_prepaid_order_open($order_no)
 
 	return $result[0];
 }
+
+function last_sales_order_detail($order, $field)
+{
+        $sql = "SELECT $field
+                        FROM ".TB_PREF."sales_order_details d"
+                        ." LEFT JOIN " .TB_PREF."sales_orders o on d.order_no=o.order_no
+                        WHERE debtor_no=" . db_escape($order->customer_id)
+                        . " ORDER BY d.id DESC LIMIT 1";
+
+        $last_query=db_query($sql, "Retreive last order detail");
+        $row = db_fetch_row($last_query);
+        return $row[0];
+}
+

--- a/core/sales/includes/ui/sales_order_ui.inc
+++ b/core/sales/includes/ui/sales_order_ui.inc
@@ -502,13 +502,14 @@ function sales_order_item_controls(&$order, &$rowcounter, $line_no=-1)
 		if ($order->fixed_asset)
 			stock_disposable_fa_list_cells(null,'stock_id', null, _('[Select item]'), true, $order->line_items);
 		else
-			sales_items_list_cells(null,'stock_id', null, false, true, true);
 		if (list_updated('stock_id')) {
+                            sales_items_list_cells(null,'stock_id', null, false, true, true);
 			    $Ajax->activate('price');
 			    $Ajax->activate('units');
 			    $Ajax->activate('qty');
 			    $Ajax->activate('line_total');
-		}
+		} else
+			 sales_items_list_cells(null,'stock_id', last_sales_order_detail($order, 'stk_code'), false, true, true);
 
 		$item_info = get_item_edit_info($_POST['stock_id']);
 		$units = $item_info["units"];


### PR DESCRIPTION
admin/void_transaction.php: do not unset date to allow subsequent voids on that date
gl/bank_account_reconcile.php: display memo, new "reconcile all" transactions on page feature
gl/gl_journal.php: allow user to retain reconciled status of transaction during modify
gl/includes/db/gl_db_bank_accounts.inc: display memo on bank reconciliation (which often contains check number)
gl/includes/db/gl_db_bank_trans.inc: support for last_bank_trans recall
gl/includes/db/gl_db_trans.inc: support to search gl transactions by memo, fix mantis bug 4161, support for display of transactions with no dimension
gl/includes/ui/gl_bank_ui.inc: recall dimension during supplier payments (prior behavior was no dimension)
gl/includes/ui/gl_journal_ui.inc: allow user to retain reconciled status of transaction
gl/inquiry/gl_account_inquiry.php: support for display of transactions with no dimension, allow search by memo, allow editing of journal entries from G/L inquiry
purchasing/includes/db/suppliers_db.inc: support for dimension recall during supplier payments
reporting/rep105.php: do not generate empty report
reporting/rep106.php: do not generate empty report
reporting/rep108.php: do not generate empty report
reporting/rep114.php: sort by sales type, do not generate empty report
sales/includes/db/sales_invoice_db.inc: support for recall of last sales order item
sales/includes/ui/sales_order_ui.inc: recall last sales order item for new item line (prior behavior was first inventory item, not very useful)
