### PR TITLE
apportion service costs to item prices; bug fixes

### DIFF
--- a/core/includes/current_user.inc
+++ b/core/includes/current_user.inc
@@ -353,7 +353,9 @@ function price_decimal_format($number, &$dec)
 	if ($pos !== false)
 	{
 		$len = strlen(substr($str, $pos + 1));
-		if ($len > $dec && $len < ini_get('precision')-3)
+		if ($len > ini_get('precision')-3)
+                    $len = ini_get('precision')-3;
+		if ($len > $dec)
 			$dec = $len;
 	}
 	return number_format2($number, $dec);

--- a/core/purchasing/includes/db/po_db.inc
+++ b/core/purchasing/includes/db/po_db.inc
@@ -284,6 +284,7 @@ function get_short_info($stock_id)
 function get_sql_for_po_search_completed($from, $to, $supplier_id=ALL_TEXT, $location=ALL_TEXT,
 	$order_number = '', $stock_id = '', $also_closed=false)
 {
+        $dec = user_price_dec();
 	$sql = "SELECT 
 		porder.order_no, 
 		porder.reference, 
@@ -292,7 +293,7 @@ function get_sql_for_po_search_completed($from, $to, $supplier_id=ALL_TEXT, $loc
 		porder.requisition_no, 
 		porder.ord_date, 
 		supplier.curr_code, 
-		Sum(line.unit_price*line.quantity_ordered) AS OrderValue,
+                Sum(Round(line.unit_price*line.quantity_ordered, $dec)) AS OrderValue,
 		porder.into_stock_location,
 		chk.isopen
 		FROM ".TB_PREF."purch_orders as porder
@@ -344,6 +345,7 @@ function get_sql_for_po_search_completed($from, $to, $supplier_id=ALL_TEXT, $loc
 
 function get_sql_for_po_search($from, $to, $supplier_id=ALL_TEXT, $location=ALL_TEXT, $order_number='', $stock_id='')
 {
+        $dec = user_price_dec();
 	$sql = "SELECT 
 		porder.order_no, 
 		porder.reference,
@@ -352,7 +354,7 @@ function get_sql_for_po_search($from, $to, $supplier_id=ALL_TEXT, $location=ALL_
 		porder.requisition_no, 
 		porder.ord_date,
 		supplier.curr_code,
-		Sum(line.unit_price*line.quantity_ordered) AS OrderValue,
+                Sum(Round(line.unit_price*line.quantity_ordered, $dec)) AS OrderValue,
 		Sum(line.delivery_date < '". date2sql(Today()) ."'
 		AND (line.quantity_ordered > line.quantity_received)) As OverDue
 		FROM ".TB_PREF."purch_orders as porder,"

--- a/core/purchasing/includes/po_class.inc
+++ b/core/purchasing/includes/po_class.inc
@@ -168,6 +168,21 @@ class purch_order
 	}
 
 	/*
+		Returns order subtotal
+	*/
+	function get_trans_subtotal() {
+		
+		$total = 0;
+		$dec = user_price_dec();
+
+		foreach ($this->line_items as $ln_itm) {
+			$value = round($ln_itm->quantity * $ln_itm->price, $dec);
+			$total += $value;
+                }
+                return $total;
+        }
+
+	/*
 		Returns order value including all taxes
 	*/
 	function get_trans_total() {
@@ -191,6 +206,82 @@ class purch_order
 		}
 		return $total;
 	}
+
+        function is_service_item($stock_id)
+        {
+                $item_row = get_item($stock_id);
+                if (!$item_row) 
+                        return false;
+                return is_service($item_row['mb_flag']);
+        }
+
+        function service_price_per_line($method)
+        {
+            $total_service = 0;
+            $total = 0;
+            $dec = user_price_dec();
+
+            foreach ($this->line_items as $ln_itm) {
+                if ($this->is_service_item($ln_itm->stock_id)) {
+                    $value = round($ln_itm->quantity * $ln_itm->price, $dec);
+                    $total_service += $value;
+                } else {
+                    if ($method == 1)
+                        $total += $ln_itm->quantity;
+                    else if ($method == 2)
+                        $total++;
+                    else {
+                        $value = round($ln_itm->quantity * $ln_itm->price, $dec);
+                        $total += $value;
+                    }
+                }
+            }
+            if ($total == 0)
+                return 0;
+
+            return $total_service / $total;
+        }
+
+        // Apportion service price line items to non-service items
+        // and zero out service item price
+
+        // Common methods to apportion service charges are:
+        // by quantity, weight, volume, line item, line total.
+        // $method: 1 Quantity
+        //          2 Line Item
+        //          3 Line Total
+
+        function reprice_order($method)
+        {
+            $service_cost = $this->service_price_per_line($method);
+            if ($service_cost == 0)
+                return;
+
+            $total = $this->get_trans_subtotal();
+            $dec = user_price_dec();
+            foreach ($this->line_items as $ln_itm) {
+                    if ($this->is_service_item($ln_itm->stock_id))
+                        $ln_itm->price = 0;
+                    else {
+                        if ($method == 1)
+                            $ln_itm->price += $service_cost;
+                        else if ($method == 2)
+                            $ln_itm->price += $service_cost / $ln_itm->quantity;
+                        else {
+                            $value = round($ln_itm->quantity * $ln_itm->price, $dec);
+                            $ln_itm->price += $service_cost * $value / $ln_itm->quantity;
+                        }
+                        $last_ln = $ln_itm;
+                    }
+            }
+            $total2 = $this->get_trans_subtotal();
+            if ($total != $total2) {
+            // uh oh, rounding broke the invoice total
+            // change the price of the last item to fix it
+                $last_ln->price = ($last_ln->quantity * $last_ln->price + $total - $total2)/$last_ln->quantity;
+            }
+        }
+
 
 } /* end of class defintion */
 

--- a/core/purchasing/includes/ui/po_ui.inc
+++ b/core/purchasing/includes/ui/po_ui.inc
@@ -62,6 +62,37 @@ function copy_to_cart()
 	}
 }
 
+function service_alg_list($name, $selected_id=null, $submit_on_change=false)
+{
+        $items = array();
+        $items['0'] =  _("No");
+        $items['1'] =  _("By Quantity");
+        $items['2'] =  _("By Line Item");
+        $items['3'] =  _("By Line Total");
+
+        return array_selector($name, $selected_id, $items,
+                array(
+                        'select_submit'=> $submit_on_change,
+                        'async' => false ) ); // FIX?
+}
+
+function service_alg_list_cells($label, $name, $selected_id=null, $submit_on_change=false)
+{
+        if ($label != null)
+                echo "<td>$label</td>\n";
+        echo "<td>";
+        echo service_alg_list($name, $selected_id, $submit_on_change);
+        echo "</td>\n";
+}
+
+function service_alg_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+{
+        echo "<tr><td class='label'>$label</td>";
+        service_alg_list_cells(null, $name, $selected_id, $submit_on_change);
+        echo "</tr>\n";
+}
+
+
 //---------------------------------------------------------------------------------------------------
 
 function create_new_po($trans_type, $trans_no)
@@ -173,6 +204,7 @@ function display_po_header(&$order)
 	if (get_company_pref('use_dimension') == 2)
 		dimensions_list_row(_('Dimension 2').':', 'dimension2', null, true, _('Default'), false, 2);
 	locations_list_row(_("Receive Into:"), 'StkLocation', null, false, true, $order->fixed_asset); 
+        service_alg_list_row(_('Service Costs In Item Prices?'), 'reprice');
 
 	table_section(3);
 

--- a/core/purchasing/po_entry_items.php
+++ b/core/purchasing/po_entry_items.php
@@ -240,7 +240,12 @@ function check_data()
 	   	return false;
     }
 
-    if (!check_num('price', 0))
+    // Note: if the item is a service and the user wants to reprice
+    // the order, allow negative input, as the service item will
+    // zeroed out anyway.
+
+    if (!check_num('price', 0)
+        && !($_POST['reprice'] != 0 && $_SESSION['PO']->is_service_item($_POST['stock_id'])))
     {
 	   	display_error(_("The price entered must be numeric and not less than zero."));
 		set_focus('price');
@@ -274,6 +279,8 @@ function handle_update_item()
 	
 		$_SESSION['PO']->update_order_item($_POST['line_no'], input_num('qty'), input_num('price'),
   			@$_POST['req_del_date'], $_POST['item_description'] );
+                if ($_POST['reprice'] != 0)
+                    $_SESSION['PO']->reprice_order($_POST['reprice']);
 		unset_form_variables();
 	}	
     line_start_focus();
@@ -315,6 +322,8 @@ function handle_add_new_item()
 					get_post('stock_id_text'), //$myrow["description"], 
 					input_num('price'), '', // $myrow["units"], (retrived in cart)
 					$_SESSION['PO']->trans_type == ST_PURCHORDER ? $_POST['req_del_date'] : '', 0, 0);
+                                if ($_POST['reprice'] != 0)
+                                    $_SESSION['PO']->reprice_order($_POST['reprice']);
 
 				unset_form_variables();
 				$_POST['stock_id']	= "";
@@ -437,6 +446,7 @@ function handle_commit_order()
 		}
 	}
 }
+
 //---------------------------------------------------------------------------------------------------
 if (isset($_POST['update'])) {
 	copy_to_cart();

--- a/core/purchasing/po_receive_items.php
+++ b/core/purchasing/po_receive_items.php
@@ -82,7 +82,7 @@ function display_po_receive_items()
     	    	$ln_itm->receive_qty = $qty_outstanding;
     		}
 
-    		$line_total = ($ln_itm->receive_qty * $ln_itm->price);
+    		$line_total = price_format($ln_itm->receive_qty * $ln_itm->price);
     		$total += $line_total;
 
 			label_cell($ln_itm->stock_id);

--- a/core/purchasing/view/view_po.php
+++ b/core/purchasing/view/view_po.php
@@ -77,11 +77,10 @@ foreach ($purchase_order->line_items as $stock_item)
 	qty_cell($stock_item->qty_inv, false, $dec);
 	end_row();
 
-	$total += $line_total;
+	$total += price_format($line_total);
 }
 
-$display_sub_tot = number_format2($total,user_price_dec());
-label_row(_("Sub Total"), $display_sub_tot,
+label_row(_("Sub Total"), price_format($total),
 	"align=right colspan=6", "nowrap align=right",2);
 
 $taxes = $purchase_order->get_taxes();

--- a/core/sales/includes/db/sales_credit_db.inc
+++ b/core/sales/includes/db/sales_credit_db.inc
@@ -152,8 +152,9 @@ function write_credit_note(&$credit_note, $write_off_acc)
 				$taxitem['rate'], $credit_note->tax_included, $taxitem['Value'],
 				$taxitem['Net'], $ex_rate,
 				$credit_note->document_date, $credit_note->reference, TR_OUTPUT);
-
-			$total += add_gl_trans_customer(ST_CUSTCREDIT, $credit_no, $credit_date, $taxitem['sales_gl_code'], 0, 0,
+                        // sales_gl_code is not set for taxexempt
+                        if (isset($taxitem['sales_gl_code']))
+                            $total += add_gl_trans_customer(ST_CUSTCREDIT, $credit_no, $credit_date, $taxitem['sales_gl_code'], 0, 0,
 				$taxitem['Value'], $credit_note->customer_id,
 				"A tax GL posting for this credit note could not be inserted");
 		}


### PR DESCRIPTION
This mod gives the user the option on a PO to apportion service items (freight, setup charges, discounts, etc)  into prices of non-service items on the PO without changing the PO order total.      By apportioning these costs into item prices, they are accounted for in inventory and thus accounted for in COGS only when then items are sold.  Three methods of apportionment are provided: by item quantity, line item, and line total. 

additional bug fixes:

1. Viewing order totals on POs with items with decimal precision greater than user decimals could be wrong because of rounding.   Changes in the code reflect the method used to generate the PO, by rounding each line item to user decimals, then adding.  Prior code added then rounded.

2. php.ini precision could cause disabling of FA PO decimal precision for items with precise Conversion Factors.  Fix was to use php.ini precision rather than disable the feature.

3. credit memos for tax exempt items do not have tax gl account, and code generated a PHP warning.  This did not cause any problem other than the PHP warning, because G/L was created on the remaining total.